### PR TITLE
Updated package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@types/react-native-modalbox": "^1.4.2",
     "@types/prop-types": "^15.5.1",
-    "react-native-modalbox": "^1.4.2",
+    "react-native-modalbox": "^2.0.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated outdated dependencies. Several code in ModalBox version 1.4.2 is deprecated for React Native >= 0.60. Version 2.0.0 works fine and without warnings.